### PR TITLE
Add Makefile for student management system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Name of the final executable
+TARGET = student_management_system
+
+# Compiler and its options
+CC = gcc
+CFLAGS = -Wall -Wextra -Iinclude
+
+# Source files
+SRCS = src/main.c src/student.c src/utils.c
+
+# Main rule to compile the program
+$(TARGET): $(SRCS)
+	$(CC) $(CFLAGS) $^ -o $@
+
+# Rule to clean generated files
+clean:
+	rm -f $(TARGET)
+
+.PHONY: clean


### PR DESCRIPTION
- Added Makefile with the following features:
  - Defined TARGET as 'student_management_system'
  - Set compiler to gcc with flags -Wall and -Wextra
  - Included header files from 'include' directory
  - Specified source files: src/main.c, src/student.c, src/utils.c
  - Main rule to compile the program into the final executable
  - Clean rule to remove the generated executable file

- Added .PHONY target for 'clean' to ensure proper cleaning of generated files.